### PR TITLE
This is a test, please ignore.... Release checklist for staging

### DIFF
--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -253,8 +253,12 @@ class BulkDownload < ApplicationRecord
   end
 
   def bulk_download_ecs_task_command
-    samples = Sample.where(id: pipeline_runs.map(&:sample_id))
-    projects = Project.where(id: samples.pluck(:project_id))
+    # Order both pipeline runs and samples by ascending sample id.
+    # This ensures that the download src-urls and tar-names have the same order which is critical to
+    # mapping the file content to the correct file name.
+    pipeline_runs_ordered = pipeline_runs.order(:sample_id)
+    samples_ordered = Sample.where(id: pipeline_runs.map(&:sample_id)).order(:id)
+    projects = Project.where(id: samples_ordered.pluck(:project_id))
 
     # Compute cleaned project name once instead of once per sample.
     cleaned_project_names = {}
@@ -266,14 +270,14 @@ class BulkDownload < ApplicationRecord
     download_tar_names = nil
 
     if download_type == ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE
-      samples = samples.includes(:input_files)
+      samples_ordered = samples_ordered.includes(:input_files)
 
-      download_src_urls = samples.map(&:input_file_s3_paths).flatten
+      download_src_urls = samples_ordered.map(&:input_file_s3_paths).flatten
 
       # We use the sample name in the output file names (instead of the original input file names)
       # because the sample name is what's visible to the user.
       # Also, there might be duplicates between the original file names.
-      download_tar_names = samples.map do |sample|
+      download_tar_names = samples_ordered.map do |sample|
         # We assume that the first input file is R1 and the second input file is R2. This is the convention that the pipeline follows.
         sample.input_files.map.with_index do |input_file, input_file_index|
           # Include the project id because the cleaned project names might have duplicates as well.
@@ -284,29 +288,29 @@ class BulkDownload < ApplicationRecord
     end
 
     if download_type == UNMAPPED_READS_BULK_DOWNLOAD_TYPE
-      download_src_urls = pipeline_runs.map(&:unidentified_fasta_s3_path)
+      download_src_urls = pipeline_runs_ordered.map(&:unidentified_fasta_s3_path)
 
-      download_tar_names = samples.map do |sample|
+      download_tar_names = samples_ordered.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
           "unmapped.fasta"
       end
     end
 
     if download_type == READS_NON_HOST_BULK_DOWNLOAD_TYPE && get_param_value("file_format") == ".fasta"
-      download_src_urls = pipeline_runs.map(&:annotated_fasta_s3_path)
+      download_src_urls = pipeline_runs_ordered.map(&:annotated_fasta_s3_path)
 
-      download_tar_names = samples.map do |sample|
+      download_tar_names = samples_ordered.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
           "reads_nh.fasta"
       end
     end
 
     if download_type == READS_NON_HOST_BULK_DOWNLOAD_TYPE && get_param_value("file_format") == ".fastq"
-      pipeline_runs_with_assocs = pipeline_runs.includes(sample: [:input_files])
+      pipeline_runs_ordered = pipeline_runs_ordered.includes(sample: [:input_files])
 
-      download_src_urls = pipeline_runs_with_assocs.map(&:nonhost_fastq_s3_paths).flatten
+      download_src_urls = pipeline_runs_ordered.map(&:nonhost_fastq_s3_paths).flatten
 
-      download_tar_names = pipeline_runs_with_assocs.map do |pipeline_run|
+      download_tar_names = pipeline_runs_ordered.map do |pipeline_run|
         sample = pipeline_run.sample
         file_ext = sample.fasta_input? ? 'fasta' : 'fastq'
         # We assume that the first input file is R1 and the second input file is R2. This is the convention that the pipeline follows.
@@ -319,18 +323,18 @@ class BulkDownload < ApplicationRecord
     end
 
     if download_type == CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE
-      download_src_urls = pipeline_runs.map(&:contigs_fasta_s3_path)
+      download_src_urls = pipeline_runs_ordered.map(&:contigs_fasta_s3_path)
 
-      download_tar_names = samples.map do |sample|
+      download_tar_names = samples_ordered.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
             "contigs_nh.fasta"
       end
     end
 
     if download_type == HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE
-      download_src_urls = pipeline_runs.map(&:host_gene_count_s3_path)
+      download_src_urls = pipeline_runs_ordered.map(&:host_gene_count_s3_path)
 
-      download_tar_names = samples.map do |sample|
+      download_tar_names = samples_ordered.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
           "reads_per_gene.star.tab"
       end

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -269,6 +269,122 @@ describe BulkDownload, type: :model do
 
       expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
     end
+
+    it "returns the correct task command regardless of the order in which pipeline runs are passed in" do
+      # Here, we pass in sample_two's pipeline BEFORE sample_one's.
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
+                                @sample_two.first_pipeline_run.id,
+                                @sample_one.first_pipeline_run.id,
+                              ], params: {
+                                "file_format" => {
+                                  "value" => ".fastq",
+                                  "displayName" => ".fastq",
+                                },
+                              })
+
+      task_command = [
+        "python",
+        "s3_tar_writer.py",
+        "--src-urls",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R2.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R2.fastq",
+        "--tar-names",
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R2.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
+        "--dest-url",
+        "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--success-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
+        "--error-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}",
+        "--progress-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
+      ]
+
+      expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
+    end
+
+    it "returns the correct task command regardless of the ordering of pipeline run ids" do
+      # Here, sample_one.id < sample_two.id, but sample_one.first_pipeline_run.id > sample_two.first_pipeline_run.id
+      # This simulates a situation where subsequent pipeline runs are run "out of order".
+      create(:pipeline_run, sample: @sample_two, finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12")
+      create(:pipeline_run, sample: @sample_one, finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12")
+
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
+                                @sample_one.first_pipeline_run.id,
+                                @sample_two.first_pipeline_run.id,
+                              ], params: {
+                                "file_format" => {
+                                  "value" => ".fastq",
+                                  "displayName" => ".fastq",
+                                },
+                              })
+
+      task_command = [
+        "python",
+        "s3_tar_writer.py",
+        "--src-urls",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R2.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R2.fastq",
+        "--tar-names",
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R2.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
+        "--dest-url",
+        "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--success-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
+        "--error-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}",
+        "--progress-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
+      ]
+
+      expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
+
+      # Here, we pass in sample_two's pipeline BEFORE sample_one's.
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
+                                @sample_two.first_pipeline_run.id,
+                                @sample_one.first_pipeline_run.id,
+                              ], params: {
+                                "file_format" => {
+                                  "value" => ".fastq",
+                                  "displayName" => ".fastq",
+                                },
+                              })
+
+      task_command = [
+        "python",
+        "s3_tar_writer.py",
+        "--src-urls",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/nonhost_R2.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R2.fastq",
+        "--tar-names",
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R2.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
+        "--dest-url",
+        "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--success-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
+        "--error-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}",
+        "--progress-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
+      ]
+
+      expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
+    end
   end
 
   context "#aegea_ecs_submit_command" do


### PR DESCRIPTION
## Please check the following commits after testing them:
### Mark Zhang
* [ ] cf2e224b - [Hot fix CP] Fix ordering bug for bulk download ecs task command. (#2916) (#2917)  (tag: v0.21_prod_2020-01-07, origin/prod) (Fri, 3 Jan 2020 13:41:11 -0800)
* [ ] 483a36a8 - Always use execute option for bulk download fargate tasks. (#2915)  (tag: v0.21_staging_2020-01-02) (Thu, 2 Jan 2020 11:35:32 -0800)
* [ ] 3b3f8004 - Handle long sample names in bulk download and fix toolbarIcon onClick. (#2914)  (Tue, 31 Dec 2019 15:38:47 -0800)
* [ ] b3b3c603 - Add logging to Syscall functions. (#2913)  (Tue, 31 Dec 2019 17:29:31 -0600)
* [ ] 1b17a236 - Add restrictions to privacy-sensitive bulk downloads. (#2911)  (Mon, 30 Dec 2019 12:07:34 -0800)
* [ ] 84ce46db - Add user settings and user-facing settings page (#2900)  (Fri, 20 Dec 2019 17:34:14 -0800)
* [ ] e0088391 - Add admin options for bulk downloads (#2907)  (Thu, 19 Dec 2019 17:05:58 -0800)
* [ ] d6136fd9 - Fix bug with overactive logging in bulk download. (#2906)  (Thu, 19 Dec 2019 16:55:11 -0800)
### Greg Dingle
* [ ] 58a38d1a - Replace references to "tissue" with "sample type" (#2902)  (Thu, 19 Dec 2019 14:02:31 -0800)
### Jonathan Sheu
* [ ] 1d1d58f6 - Fix bugs and edge cases in User Create/Update flows (#2912)  (Tue, 31 Dec 2019 15:51:59 -0800)
* [ ] bf4f36e5 - [IDSEQ-1952] Add new fish hosts (#2899)  (Thu, 19 Dec 2019 13:48:13 -0800)
### Julie Han
* [ ] b6f5d95d - [Report Page] Tweak design and styling (#2901)  (tag: v0.20_staging_2019-12-19, tag: v0.20_prod_2020-01-02) (Thu, 19 Dec 2019 16:22:47 -0800)
* [ ] d004dd00 - [Report page] Fix contig/contig r threshold filters (#2910)  (Thu, 19 Dec 2019 15:53:19 -0800)
### Andrey Kislyuk
* [ ] f23c45d6 - Add a Rake task to export DAGs (#2909)  (Thu, 19 Dec 2019 20:02:38 -0800)
* [ ] 1acca7fd - Update README.md (#2908)  (Thu, 19 Dec 2019 12:12:40 -0800)